### PR TITLE
fixes non-pnx tokens to point to root if their parent is pnx

### DIFF
--- a/src/data_preparation.py
+++ b/src/data_preparation.py
@@ -7,6 +7,7 @@ from camel_tools.disambig.common import DisambiguatedWord
 
 from src.utils.comma_fix import fix_sentence_commas
 from src.utils.conll_fixes import adjust_eof_newlines
+from src.utils.fix_pnx_head import pnx_head_fix
 from .classes import ConllParams, TextParams, PreprocessedTextParams, TokenizedParams, TokenizedTaggedParams, get_conll_tree_header_list
 from .dependency_parser.biaff_parser import parse_conll, parse_text_tuples
 from .initialize_disambiguator.disambiguator_interface import get_disambiguator
@@ -189,9 +190,9 @@ def parse_text(file_type: str, file_type_params: FileTypeParams):
         parsed_text_tuples = add_feats(parsed_text_tuples, text_feats)
     df_list = [pd.DataFrame(sentence_tree_tuples, columns=get_conll_tree_header_list()).astype({'ID': 'int32', 'HEAD': 'int32'}) for sentence_tree_tuples in parsed_text_tuples]
 
-    # import pdb; pdb.set_trace()
-    comma_fixed_trees = [fix_sentence_commas(df) for df in df_list]
+    pnx_head_fixed_trees = [pnx_head_fix(df) for df in df_list]
 
+    comma_fixed_trees = [fix_sentence_commas(df) for df in pnx_head_fixed_trees]
     comma_fixed_trees_tuple = [list(df.itertuples(index=False, name=None)) for df in comma_fixed_trees]
 
     return comma_fixed_trees_tuple

--- a/src/utils/comma_fix.py
+++ b/src/utils/comma_fix.py
@@ -167,7 +167,7 @@ def get_comma_id_list(conllx_df: DataFrame) -> List[int]:
 # def fix_comma(comma_id: int, conllx_df: DataFrame) -> Union[DataFrame, Exception]:
 def fix_comma(comma_id: int, conllx_df: DataFrame) -> Union[DataFrame, bool]:
     """The algorithm is as follows:
-    check if the tree is projective, otherwise raise an exception
+    check if the tree is projective, otherwise return tree unchanged
     get the token before it
         is the the token a root?
         is the the token ahead of the comma?

--- a/src/utils/fix_pnx_head.py
+++ b/src/utils/fix_pnx_head.py
@@ -1,0 +1,13 @@
+
+
+
+
+def fix_pnx_parent(row, conllx_df):
+    if row.UPOS != 'PNX' and conllx_df[conllx_df.ID == row.HEAD].iloc[0].UPOS == 'PNX':
+        return 0
+    return row.HEAD
+
+def pnx_head_fix(conllx_df):
+    "If a token that is not a PNX attaches to a token that is a PNX, adjust the attachment such that it attaches to ROOT"
+    conllx_df.HEAD = conllx_df.apply(fix_pnx_parent, axis=1, args=(conllx_df,))
+    return conllx_df


### PR DESCRIPTION
Before fixing comma attachments, the code first checks to see if non-PNX tokens have PNX tokens as a HEAD. If so, the code will set the HEAD to be ROOT (ID=0) instead.